### PR TITLE
Attempt to install rustup when not present

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "${CARGO_HOME:-~/.cargo}/bin" >> $GITHUB_PATH
         fi
       if: runner.os != 'Windows'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,14 @@ runs:
         targets: ${{inputs.target}}
         components: ${{inputs.components}}
       shell: bash
+    - name: "Install rustup if needed"
+      run: |
+        if ! command -v rustup &> /dev/null ; then
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        fi
+      if: runner.os != 'Windows'
+      shell: bash
     - name: rustup toolchain install ${{inputs.toolchain}}
       run: rustup toolchain install ${{inputs.toolchain}}${{steps.flags.outputs.targets}}${{steps.flags.outputs.components}} --profile minimal${{steps.flags.outputs.downgrade}} --no-self-update
       shell: bash


### PR DESCRIPTION
I'd like to switch to `dtolnay/rust-toolchain` in some future projects instead of `actions-rs/toolchain`, but unfortunately this causes issues with my own personal workflow. Specifically, I often use the `act` CLI tool (https://github.com/nektos/act) to run the GHA CI locally before submitting a PR.

Unfortunately, it seems the containers `act` uses by default are intentionally stripped down to reduce overhead since it creates a lot of these containers during execution. For whatever reason (presumably the fact that a rust toolchain is fairly large), these don't seem come with rustup installed, so use of `dtolnay/rust-toolchain` causes errors like "rustup: command not found" (conversely, because `actions-rs/toolchain` auto-installs rustup when not present, it works fine with `act`). Automatically installing rustup when not present, as done in this PR, fixes the issue.

In principal, I think this may also help actions that use a non-default docker container image to run their actions. (That said, this on its own is not very convincing, since it's probably better for these users to just ensure that their custom container has rustup).

---

Anyway, one concern is Windows. I've explicitly disabled this step on windows runners for a couple reasons:

1. The script would need a few changes and added complexity.

	While the `sh.rustup.rs` script does seem to have some windows support, it might be cygwin/mingw-only, and `win.rustup.rs` seems preferred (I'm not sure the `sh` binary would be available).

	Not to mention, `$HOME/.cargo/bin` would be wrong on Windows as well, and it should (maybe?) be `$USERPROFILE/.cargo/bin` there? Not sure.

2. I'm not sure how useful it is, at the moment.

	`act` doesn't support Windows (it ignores those CI tasks), and I don't think you can use custom containers for windows runners on GHA either.

	So... I'm not sure when you wouldn't have `rustup` installed on a GHA runner (perhaps a self-hosted runner?), and don't know how this could be tested on them. Either way, it does not seem worth the trouble.

That said, this is somewhat subject to change, and it's possible at some point I'll submit a PR adding windows support to this.