### PR TITLE
Move title of rustup install step into the run script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
         targets: ${{inputs.target}}
         components: ${{inputs.components}}
       shell: bash
-    - name: "Install rustup if needed"
-      run: |
+    - run: |
+        : install rustup if needed
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           echo "${CARGO_HOME:-~/.cargo}/bin" >> $GITHUB_PATH


### PR DESCRIPTION
For whatever reason, GitHub Actions does not render the `name` of the step, only the first line of the script.

<br>

**Before:**

![Screenshot from 2022-06-04 16-39-25](https://user-images.githubusercontent.com/1940490/172029048-42a05fd9-bb32-4db5-8b77-c66fd32571e0.png)
