### PR TITLE
Print git push command at end of update-revs.sh

### DIFF
--- a/scripts/update-revs.sh
+++ b/scripts/update-revs.sh
@@ -8,6 +8,7 @@ if ! git diff-index --quiet HEAD; then
 fi
 
 base=$(git rev-parse HEAD)
+push=()
 
 for rev in 1.{0..70}.0 stable beta nightly; do
     echo "Updating $rev branch"
@@ -17,6 +18,7 @@ for rev in 1.{0..70}.0 stable beta nightly; do
     git add action.yml
     git commit --quiet --message "toolchain: $rev"
     git checkout --quiet -b $rev
+    push+=("$rev:refs/heads/$rev")
 done
 
 for tool in clippy miri; do
@@ -27,6 +29,9 @@ for tool in clippy miri; do
     git add action.yml
     git commit --quiet --message "components: $tool"
     git checkout --quiet -b $tool
+    push+=("$tool:refs/heads/$tool")
 done
 
 git checkout --quiet "$base"
+
+echo "git push origin --force-with-lease ${push[@]}"


### PR DESCRIPTION
```console
git push origin --force-with-lease 1.0.0:refs/heads/1.0.0 1.1.0:refs/heads/1.1.0 1.2.0:ref
s/heads/1.2.0 1.3.0:refs/heads/1.3.0 1.4.0:refs/heads/1.4.0 1.5.0:refs/heads/1.5.0 1.6.0:r
efs/heads/1.6.0 1.7.0:refs/heads/1.7.0 1.8.0:refs/heads/1.8.0 1.9.0:refs/heads/1.9.0 1.10.
0:refs/heads/1.10.0 1.11.0:refs/heads/1.11.0 1.12.0:refs/heads/1.12.0 1.13.0:refs/heads/1.
13.0 1.14.0:refs/heads/1.14.0 1.15.0:refs/heads/1.15.0 1.16.0:refs/heads/1.16.0 1.17.0:ref
s/heads/1.17.0 1.18.0:refs/heads/1.18.0 1.19.0:refs/heads/1.19.0 1.20.0:refs/heads/1.20.0 
1.21.0:refs/heads/1.21.0 1.22.0:refs/heads/1.22.0 1.23.0:refs/heads/1.23.0 1.24.0:refs/hea
ds/1.24.0 1.25.0:refs/heads/1.25.0 1.26.0:refs/heads/1.26.0 1.27.0:refs/heads/1.27.0 1.28.
0:refs/heads/1.28.0 1.29.0:refs/heads/1.29.0 1.30.0:refs/heads/1.30.0 1.31.0:refs/heads/1.
31.0 1.32.0:refs/heads/1.32.0 1.33.0:refs/heads/1.33.0 1.34.0:refs/heads/1.34.0 1.35.0:ref
s/heads/1.35.0 1.36.0:refs/heads/1.36.0 1.37.0:refs/heads/1.37.0 1.38.0:refs/heads/1.38.0 
1.39.0:refs/heads/1.39.0 1.40.0:refs/heads/1.40.0 1.41.0:refs/heads/1.41.0 1.42.0:refs/hea
ds/1.42.0 1.43.0:refs/heads/1.43.0 1.44.0:refs/heads/1.44.0 1.45.0:refs/heads/1.45.0 1.46.
0:refs/heads/1.46.0 1.47.0:refs/heads/1.47.0 1.48.0:refs/heads/1.48.0 1.49.0:refs/heads/1.
49.0 1.50.0:refs/heads/1.50.0 1.51.0:refs/heads/1.51.0 1.52.0:refs/heads/1.52.0 1.53.0:ref
s/heads/1.53.0 1.54.0:refs/heads/1.54.0 1.55.0:refs/heads/1.55.0 1.56.0:refs/heads/1.56.0 
1.57.0:refs/heads/1.57.0 1.58.0:refs/heads/1.58.0 1.59.0:refs/heads/1.59.0 1.60.0:refs/hea
ds/1.60.0 1.61.0:refs/heads/1.61.0 1.62.0:refs/heads/1.62.0 1.63.0:refs/heads/1.63.0 1.64.
0:refs/heads/1.64.0 1.65.0:refs/heads/1.65.0 1.66.0:refs/heads/1.66.0 1.67.0:refs/heads/1.
67.0 1.68.0:refs/heads/1.68.0 1.69.0:refs/heads/1.69.0 1.70.0:refs/heads/1.70.0 stable:ref
s/heads/stable beta:refs/heads/beta nightly:refs/heads/nightly clippy:refs/heads/clippy mi
ri:refs/heads/miri
```