### PR TITLE
Disambiguate action name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: rustup
+name: rustup toolchain install
 author: David Tolnay
 description: Install the Rust toolchain
 


### PR DESCRIPTION
GitHub Marketplace requires:

> *Name must be unique. Cannot match an existing action, user or organization name.*

There is an existing user @rustup so "rustup" as an Action name was not allowed.