### PR TITLE
Install rust-src component by default for miri toolchain

### DIFF
--- a/scripts/update-revs.sh
+++ b/scripts/update-revs.sh
@@ -34,7 +34,9 @@ for tool in clippy miri; do
     echo "Updating $tool branch"
     git checkout --quiet --detach nightly
     git branch --quiet --delete --force $tool &>/dev/null || true
-    sed -i "/required: false/{N;s/\n$/\n    default: $tool\n/}" action.yml
+    default=$tool
+    if [ $tool == miri ]; then default+=,\ rust-src; fi
+    sed -i "/required: false/{N;s/\n$/\n    default: $default\n/}" action.yml
     git add action.yml
     git commit --quiet --message "components: $tool"
     git checkout --quiet -b $tool


### PR DESCRIPTION
Without this, `cargo miri` will download rust-src on first run, which is slower than installing it up front.

```console
Running `"rustup" "component" "add" "rust-src"` to install the `rust-src` component for the selected toolchain.
info: downloading component 'rust-src'
info: installing component 'rust-src'
```