### PR TITLE
Install xargo with miri toolchain

### DIFF
--- a/scripts/update-revs.sh
+++ b/scripts/update-revs.sh
@@ -34,9 +34,13 @@ for tool in clippy miri; do
     echo "Updating $tool branch"
     git checkout --quiet --detach nightly
     git branch --quiet --delete --force $tool &>/dev/null || true
-    default=$tool
-    if [ $tool == miri ]; then default+=,\ rust-src; fi
-    sed -i "/required: false/{N;s/\n$/\n    default: $default\n/}" action.yml
+    if [ $tool == miri ]; then
+        default="miri, rust-src"
+        echo -e "    - uses: dtolnay/install@xargo\n      with:\n        bin: xargo-check" >> action.yml
+    else
+        default=$tool
+    fi
+    sed -i "/required: false/{N;s/\n$/\n    default: $tool\n/}" action.yml
     git add action.yml
     git commit --quiet --message "components: $tool"
     git checkout --quiet -b $tool


### PR DESCRIPTION
This speeds up any subsequent miri invocation by 1m 37s. Previously they used to compile xargo from source on first run of `cargo miri`.

```console
Running `"/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo" "install" "xargo"` to install a recent enough xargo.
    Updating crates.io index
 Downloading crates ...
  Downloaded xargo v0.3.26
  Installing xargo v0.3.26
.....
    Finished release [optimized] target(s) in 1m 37s
  Installing /home/runner/.cargo/bin/xargo
  Installing /home/runner/.cargo/bin/xargo-check
   Installed package `xargo v0.3.26` (executables `xargo`, `xargo-check`)
```

https://github.com/dtolnay/semver/pull/283