### PR TITLE
Add `rustc_hash` output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   install:
-    name: Rust ${{matrix.rust}}
-    runs-on: ubuntu-latest
+    name: Rust ${{matrix.rust}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly, beta, stable, "1.16"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: ./
@@ -23,4 +24,12 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Check ${{'${{steps.toolchain.outputs.version}}'}}
         run: echo '${{steps.toolchain.outputs.version}}'
-      - run: rustc --version
+      - name: Check ${{'${{steps.toolchain.outputs.commit-hash}}'}}
+        run: echo '${{steps.toolchain.outputs.commit-hash}}'
+      - name: Check ${{'${{steps.toolchain.outputs.abbrev-hash}}'}}
+        run: echo '${{steps.toolchain.outputs.abbrev-hash}}'
+      - name: Check ${{'${{steps.toolchain.outputs.commit-date}}'}}
+        run: echo '${{steps.toolchain.outputs.commit-date}}'
+      - name: Check ${{'${{steps.toolchain.outputs.release}}'}}
+        run: echo '${{steps.toolchain.outputs.release}}'
+      - run: rustc --verbose --version

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,18 @@ outputs:
   version:
     description: Version as reported by `rustc --version`, e.g. "rustc 1.62.0 (a8314ef7d 2022-06-27)"
     value: ${{steps.rustc-version.outputs.version}}
-  rustc_hash:
-    description: The rustc hash, e.g. "a8314ef7d"
-    value: ${{steps.rustc-hash.outputs.hash}}
+  commit-hash:
+    description: The rustc source revision, e.g. "a8314ef7d0ec7b75c336af2c9857bfaf43002bfc"
+    value: ${{steps.rustc-version.outputs.commit-hash}}
+  abbrev-hash:
+    description: The abbreviated rustc source revision, e.g. "a8314ef7d"
+    value: ${{steps.rustc-version.outputs.abbrev-hash}}
+  commit-date:
+    description: The rustc source date, e.g. "2022-06-27"
+    value: ${{steps.rustc-version.outputs.commit-date}}
+  release:
+    description: The rustc version, e.g. "1.62.0"
+    value: ${{steps.rustc-version.outputs.release}}
 
 runs:
   using: composite
@@ -51,10 +60,12 @@ runs:
     - run: rustup default ${{inputs.toolchain}}
       shell: bash
     - id: rustc-version
-      run: echo "::set-output name=version::$(rustc --version)"
+      run: |
+        echo "::set-output name=version::$(rustc --version)"
+        echo "::set-output name=commit-hash::$(rustc --verbose --version | sed -ne 's/commit-hash: //p')"
+        echo "::set-output name=abbrev-hash::$(rustc --verbose --version | sed -ne 's/commit-hash: //p' | head -c9)"
+        echo "::set-output name=commit-date::$(rustc --verbose --version | sed -ne 's/commit-date: //p')"
+        echo "::set-output name=release::$(rustc --verbose --version | sed -ne 's/release: //p')"
       shell: bash
-    - id: rustc-hash
-      run: echo "::set-output name=hash::$(rustc --version | cut -d'(' -f2 -| cut -d' ' -f1)"
-      shell: bash
-    - run: rustc --version
+    - run: rustc --verbose --version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,11 @@ inputs:
 
 outputs:
   version:
-    description: Version as reported by `rustc --version`
+    description: Version as reported by `rustc --version`, e.g. "rustc 1.62.0 (a8314ef7d 2022-06-27)"
     value: ${{steps.rustc-version.outputs.version}}
+  rustc_hash:
+    description: The rustc hash, e.g. "a8314ef7d"
+    value: ${{steps.rustc-hash.outputs.hash}}
 
 runs:
   using: composite
@@ -49,6 +52,9 @@ runs:
       shell: bash
     - id: rustc-version
       run: echo "::set-output name=version::$(rustc --version)"
+      shell: bash
+    - id: rustc-hash
+      run: echo "::set-output name=hash::$(rustc --version | cut -d'(' -f2 -| cut -d' ' -f1)"
       shell: bash
     - run: rustc --version
       shell: bash


### PR DESCRIPTION
I.e. the `a8314ef7d` part in `rustc 1.62.0 (a8314ef7d 2022-06-27)`.
This makes it possible to use the output e.g. as a cache key.
`actions-rs/toolchain` has the same output with the same function.