### PR TITLE
Delete version output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
         id: toolchain
         with:
           toolchain: ${{matrix.rust}}
-      - name: Check ${{'${{steps.toolchain.outputs.version}}'}}
-        run: echo '${{steps.toolchain.outputs.version}}'
       - name: Check ${{'${{steps.toolchain.outputs.cachekey}}'}}
         run: echo '${{steps.toolchain.outputs.cachekey}}'
       - run: rustc --version

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,6 @@ outputs:
   cachekey:
     description: A short hash of the rustc version, appropriate for use as a cache key. "20220627a831"
     value: ${{steps.rustc-version.outputs.cachekey}}
-  version:
-    description: Version as reported by `rustc --version`. "rustc 1.62.0 (a8314ef7d 2022-06-27)"
-    value: ${{steps.rustc-version.outputs.version}}
 
 runs:
   using: composite
@@ -56,7 +53,6 @@ runs:
         DATE=$(rustc --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')
         HASH=$(rustc --version --verbose | sed -ne 's/^commit-hash: //p')
         echo "::set-output name=cachekey::$(echo $DATE$HASH | head -c12)"
-        echo "::set-output name=version::$(rustc --version)"
       shell: bash
     - run: rustc --version --verbose
       shell: bash


### PR DESCRIPTION
It came up in #17 that this is not well suited as a cache key, and I don't know of any other use cases for it, so most likely nowhere is using it. If there is a use, feel free to let me know and we can add it back.

#21 has a better output for the cache key use case.