### PR TITLE
Ensure version comes from the just-installed toolchain

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,9 @@ runs:
     - id: rustc-version
       run: |
         : create cachekey
-        DATE=$(rustc --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')
-        HASH=$(rustc --version --verbose | sed -ne 's/^commit-hash: //p')
+        DATE=$(rustc +${{inputs.toolchain}} --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')
+        HASH=$(rustc +${{inputs.toolchain}} --version --verbose | sed -ne 's/^commit-hash: //p')
         echo "::set-output name=cachekey::$(echo $DATE$HASH | head -c12)"
       shell: bash
-    - run: rustc --version --verbose
+    - run: rustc +${{inputs.toolchain}} --version --verbose
       shell: bash


### PR DESCRIPTION
If the caller's repo had a rust-toolchain.toml with a version number, or if they had set a `rustup override` on the current directory, it was previously possible for `rustc --version` to end up running a rustc that was different from the one just installed by the action.