### PR TITLE
Rename `target` to `targets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ All inputs are optional.
   </td>
 </tr>
 <tr>
-  <td><code>target</code></td>
-  <td>Additional target support to install e.g. <code>wasm32-unknown-unknown</code></td>
+  <td><code>targets</code></td>
+  <td>Comma-separated string of additional targets to install e.g. <code>wasm32-unknown-unknown</code></td>
 </tr>
 <tr>
   <td><code>components</code></td>

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,11 @@ inputs:
   toolchain:
     description: Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
     required: true
+  targets:
+    description: Comma-separated list of target triples to install for this toolchain
+    required: false
   target:
-    description: Target triple to install for this toolchain
+    description: Alias for `targets`
     required: false
   components:
     description: Comma-separated list of components to be additionally installed
@@ -27,6 +30,9 @@ runs:
     - id: flags
       run: |
         : construct rustup command line
+        if [[ -z "$targets" ]]; then
+          targets="$target"
+        fi
         echo "::set-output name=targets::$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)"
         echo "::set-output name=components::$(for c in ${components//,/ }; do echo -n ' --component' $c; done)"
         echo "::set-output name=downgrade::${{inputs.toolchain == 'nightly' && inputs.components && ' --allow-downgrade' || ''}}"


### PR DESCRIPTION
I was going to actually add support for multiple targets, but it looks like this script has that already. This PR renames the `target` input to `targets` to clarify that it does, in fact, support a comma-separated list of targets.