### PR TITLE
Add to GITHUB_PATH with $HOME instead of ~

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         : install rustup if needed
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "${CARGO_HOME:-~/.cargo}/bin" >> $GITHUB_PATH
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi
       if: runner.os != 'Windows'
       shell: bash


### PR DESCRIPTION
It appears the `~` is not used as expected in the `alpine` docker image when added to `GITHUB_PATH`. The `$HOME` variant should be more portable, I hope it doesn't have any additional side effects.
Discovered when analyzing https://github.com/wasmerio/wasmer/issues/3055