### PR TITLE
Enable Cargo nightly sparse-registry feature

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,5 +90,10 @@ runs:
         echo CARGO_TERM_COLOR=always >> $GITHUB_ENV
       shell: bash
 
+    - run: |
+        : enable Cargo sparse registry
+        echo CARGO_UNSTABLE_SPARSE_REGISTRY=true >> $GITHUB_ENV
+      shell: bash
+
     - run: rustc +${{steps.parse.outputs.toolchain}} --version --verbose
       shell: bash


### PR DESCRIPTION
See https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html.

Comparing:

- https://github.com/dtolnay/proc-macro2/actions/runs/3954672266/jobs/6772304513 (before)
- https://github.com/dtolnay/proc-macro2/actions/runs/3962563936/jobs/6789385636 (after)

the time for `cargo test` drops from 34 seconds (dominated by registry update overhead) to 4 seconds (dominated by useful compilation work).