### PR TITLE
Dummy package jsons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+    "name": "rust-toolchain",
+    "version": "0.0.0",
+    "lockfileVersion": 1,
+    "dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "rust-toolchain",
+    "version": "0.0.0",
+    "description": "Install the Rust toolchain",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dtolnay/rust-toolchain.git"
+    },
+    "author": "dtolnay",
+    "license": "MIT"
+}


### PR DESCRIPTION
For some reason GitHub's dependency graph UI is rendering a large number of dependencies for this repo.

Find out whether this fixes it.

![package-lock.json](https://user-images.githubusercontent.com/1940490/213881574-7edf6291-c73e-4435-96a1-34e5b48a856a.png)
![package.json](https://user-images.githubusercontent.com/1940490/213881572-5f55f2e2-6dcb-420e-a98a-a63f763db9fe.png)
