### PR TITLE
Update doc actions/checkout@v3 -> v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
 ```


### PR DESCRIPTION
Since the `actions/checkout` has been bumped to  [v4](https://github.com/actions/checkout/releases/tag/v4.0.0), the documentation should be updated accordingly.