### PR TITLE
Skip xargo installation for miri toolchain

### DIFF
--- a/scripts/update-revs.sh
+++ b/scripts/update-revs.sh
@@ -43,12 +43,8 @@ for tool in clippy miri; do
     echo "Updating $tool branch"
     git checkout --quiet --detach nightly
     git branch --quiet --delete --force $tool &>/dev/null || true
-    if [ $tool == miri ]; then
-        default="miri, rust-src"
-        echo -e "    - uses: dtolnay/install@xargo\n      with:\n        bin: xargo-check" >> action.yml
-    else
-        default=$tool
-    fi
+    default=$tool
+    if [ $tool == miri ]; then default+=,\ rust-src; fi
     sed -i "/required: false/{N;s/\n$/\n    default: $default\n/}" action.yml
     git add action.yml
     git commit --quiet --message "components: $tool"


### PR DESCRIPTION
This reverts #16. `xargo-check` is no longer needed by Miri since https://github.com/rust-lang/miri/pull/2564.