### PR TITLE
Add `CARGO_HOME` to `GITHUB_ENV`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,14 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
 
+    - run: echo CARGO_HOME=${CARGO_HOME:-$HOME/.cargo} >> $GITHUB_ENV
+      if: runner.os != 'Windows'    
+      shell: bash
+
+    - run: echo CARGO_HOME=${CARGO_HOME:-$USERPROFILE/.cargo} >> $GITHUB_ENV
+      if: runner.os == 'Windows'    
+      shell: bash
+
     - name: rustup toolchain install ${{steps.parse.outputs.toolchain}}
       run: rustup toolchain install ${{steps.parse.outputs.toolchain}}${{steps.flags.outputs.targets}}${{steps.flags.outputs.components}} --profile minimal${{steps.flags.outputs.downgrade}} --no-self-update
       shell: bash


### PR DESCRIPTION
As for other tools, it would be very useful to have `CARGO_HOME` set in the environment variable.

The default value is set referring to [Cargo guide](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads). 

Examples:
- `JAVA_HOME`
- `GRADLE_HOME`
- `ANT_HOME`
- `ANDROID_HOME`
...