### PR TITLE
Allow disabling `rustup default` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All inputs are optional.
   <td><code>make-default</code></td>
   <td>
     Make the installed toolchain the default.
-    This must be either the strings <code>'true'</code> or <code>'false'</code>, and is <code>'true'</code> by default.
+    This must be either the strings <code>true</code> or <code>false</code>, and is <code>true</code> by default.
   </td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ All inputs are optional.
   <td><code>components</code></td>
   <td>Comma-separated string of additional components to install e.g. <code>clippy, rustfmt</code></td>
 </tr>
+<tr>
+  <td><code>make-default</code></td>
+  <td>
+    Make the installed toolchain the default.
+    This must be either the strings <code>'true'</code> or <code>'false'</code>, and is <code>'true'</code> by default.
+  </td>
+</tr>
 </table>
 
 <br>

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   components:
     description: Comma-separated list of components to be additionally installed
     required: false
+  make-default:
+    description: Make the installed toolchain the default -- must be 'true' or 'false'
+    required: false
+    default: 'true'
 
 outputs:
   cachekey:
@@ -81,6 +85,7 @@ runs:
 
     - run: rustup default ${{steps.parse.outputs.toolchain}}
       shell: bash
+      if: inputs.make-default == 'true'
       continue-on-error: true  # https://github.com/dtolnay/rust-toolchain/issues/127
 
     - id: rustc-version


### PR DESCRIPTION
I'm writing an action that needs a specific Rustup nightly toolchain, but I do not want to override the default toolchain installed by users of my action (which is usually stable or a different nightly version). This PR adds a new `make-default` input (feel free to change the name) that allows you to configure whether `rustup default` is run:

```yml
# Install the stable toolchain and make it the default.
- uses: dtolnay/rust-toolchain@master
  with:
    toolchain: stable

# Install the nightly toolchain, but keep stable as the default.
# You must explicitly select `cargo +nightly` or `rustup run nightly` to use it.
- uses: dtolnay/rust-toolchain@master
  with:
    toolchain: nightly
    make-default: false
```

`make-default` is `true` by default, meaning the original behavior is kept. (It's not a breaking change!) `make-default` supports the values `true` or `false`, though the string forms of `'true'` or `"true"` also work. (Within the action, `make-default` is coerced to a string and then compared with `== 'true'`.)

I've tested my changes [using this workflow](https://github.com/BD103/rust-toolchain/blob/20ebfb710b7eaa91ee5a12534dd16f937382e462/.github/workflows/make-default.yml), which [I've run here](https://github.com/BD103/rust-toolchain/actions/runs/14596688761).

Thank you!