### PR TITLE
Use rustup.rs advertised download URLs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
     - run: |
         : install rustup if needed on windows
         if ! command -v rustup &>/dev/null; then
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://static.rust-lang.org/rustup/dist/${{ runner.arch == 'ARM64' && 'aarch64' || 'x86_64' }}-pc-windows-msvc/rustup-init.exe --output '${{runner.temp}}\rustup-init.exe'
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://win.rustup.rs/${{runner.arch == 'ARM64' && 'aarch64' || 'x86_64'}} --output '${{runner.temp}}\rustup-init.exe'
           '${{runner.temp}}\rustup-init.exe' --default-toolchain none --no-modify-path -y
           echo "$CARGO_HOME\bin" >> $GITHUB_PATH
         fi


### PR DESCRIPTION
These are the URLs provided on https://rustup.rs if you click "display all supported installers".