### PR TITLE
Support pinning the rustup version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   components:
     description: Comma-separated list of components to be additionally installed
     required: false
+  rustup-version:
+    description: The version of rustup used during installation
+    required: false
+    default: 1.28.2
 
 outputs:
   cachekey:
@@ -69,20 +73,24 @@ runs:
     - run: |
         : install rustup if needed
         if ! command -v rustup &>/dev/null; then
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | RUSTUP_VERSION="$RUSTUP_VERSION" sh -s -- --default-toolchain none -y
           echo "$CARGO_HOME/bin" >> $GITHUB_PATH
         fi
       if: runner.os != 'Windows'
+      env:
+        RUSTUP_VERSION: ${{ inputs.rustup-version }}
       shell: bash
 
     - run: |
         : install rustup if needed on windows
         if ! command -v rustup &>/dev/null; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://win.rustup.rs/${{runner.arch == 'ARM64' && 'aarch64' || 'x86_64'}} --output '${{runner.temp}}\rustup-init.exe'
-          '${{runner.temp}}\rustup-init.exe' --default-toolchain none --no-modify-path -y
+          RUSTUP_VERSION="$RUSTUP_VERSION" '${{runner.temp}}\rustup-init.exe' --default-toolchain none --no-modify-path -y
           echo "$CARGO_HOME\bin" >> $GITHUB_PATH
         fi
       if: runner.os == 'Windows'
+      env:
+        RUSTUP_VERSION: ${{ inputs.rustup-version }}
       shell: bash
 
     - name: rustup toolchain install ${{steps.parse.outputs.toolchain}}


### PR DESCRIPTION
This PR enables users to pin the `rustup` version used in this action, it defaults (to be non-breaking) to the current latest version (1.28.2). This would need updating in the future as soon as new `rustup` versions are available.

~Note: I'm not one hundred percent certain that setting the env var on Windows works the same as on Linux-based systems. I have the suspicion we might need to use the `set` command on Windows. Please feel free to suggest how this is best tested.~ **EDIT:** The CI runs seem to suggest setting the env var worked as expected.