### PR TITLE
Improve error message for missing `toolchain` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,11 @@ runs:
     - id: parse
       run: |
         : parse toolchain version
-        if [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then
+        if [[ -z $toolchain ]]; then
+          # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070
+          echo "'toolchain' is a required input" >&2
+          exit 1
+        elif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then
           if [[ ${{runner.os}} == macOS ]]; then
             echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Even though we already say the input is required, GitHub does not enforce this. https://github.com/actions/runner/issues/1070

https://github.com/dtolnay/rust-toolchain/blob/b3b07ba8b418998c39fb20f53e8b695cdcc8de1b/action.yml#L8-L11

**Before:**

<p align="center"><img width="700" src="https://github.com/user-attachments/assets/2816a2a0-86de-404a-beb7-e7c27773c430" /></p>

**After:**

<p align="center"><img width="700" src="https://github.com/user-attachments/assets/6485ab5a-3456-4ab4-bfe1-a5d4c80657b2" /></p>

Closes #159.