### PR TITLE
fix: use env var indirection for inputs.components (CMD_EXEC)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
         : construct rustup command line
         echo "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT
         echo "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT
-        if [ "$TOOLCHAIN" = "nightly" ] && [ -n "$COMPONENTS" ]; then
+        if [ "$TOOLCHAIN" = "nightly" ] && [ -n "$components" ]; then
           echo "downgrade= --allow-downgrade" >> $GITHUB_OUTPUT
         else
           echo "downgrade=" >> $GITHUB_OUTPUT
@@ -68,7 +68,6 @@ runs:
         targets: ${{inputs.targets || inputs.target || ''}}
         components: ${{inputs.components}}
         TOOLCHAIN: ${{steps.parse.outputs.toolchain}}
-        COMPONENTS: ${{inputs.components}}
       shell: bash
 
     - run: |

--- a/action.yml
+++ b/action.yml
@@ -59,10 +59,16 @@ runs:
         : construct rustup command line
         echo "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT
         echo "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT
-        echo "downgrade=${{steps.parse.outputs.toolchain == 'nightly' && inputs.components && ' --allow-downgrade' || ''}}" >> $GITHUB_OUTPUT
+        if [ "$TOOLCHAIN" = "nightly" ] && [ -n "$COMPONENTS" ]; then
+          echo "downgrade= --allow-downgrade" >> $GITHUB_OUTPUT
+        else
+          echo "downgrade=" >> $GITHUB_OUTPUT
+        fi
       env:
         targets: ${{inputs.targets || inputs.target || ''}}
         components: ${{inputs.components}}
+        TOOLCHAIN: ${{steps.parse.outputs.toolchain}}
+        COMPONENTS: ${{inputs.components}}
       shell: bash
 
     - run: |


### PR DESCRIPTION
## Security Fix: CMD_EXEC via inputs.components

### Summary
\`inputs.components\` is directly interpolated into a \`run:\` shell command via a GitHub Actions expression:
\`\`\`
echo "downgrade=\${{steps.parse.outputs.toolchain == 'nightly' && inputs.components && ' --allow-downgrade' || ''}}" >> \$GITHUB_OUTPUT
\`\`\`
A caller passing a malicious value such as \`'; arbitrary_command; echo '\` as \`components\` would execute arbitrary shell code in any job using this action.

### Fix
Replace the inline expression with equivalent shell logic using \`env:\` variables (\`TOOLCHAIN\`, \`COMPONENTS\`). Output behavior is identical: \` --allow-downgrade\` (with leading space) when toolchain is \`nightly\` and components is non-empty, empty string otherwise.

### References
- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- Rule: CMD_EXEC (CRITICAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)